### PR TITLE
Refactor frontend deployment: Build in container & serve via Nginx

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -31,3 +31,5 @@ SSL_CERT_FILE_NAME=
 
 # set this env if you want to override the os.hostname() value
 HOSTNAME=NodeName
+CORS_ORIGIN=http://localhost:10000
+COOKIE_SECRET=4c09be6a35bec6d4089cde4be5ca57a6ee85da5739579cbecb0b8253f268eca2

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you are encountering issues with attachments in the web client, it suggests t
 Now you can access apps at the following addresses:
 
 - [Server-API](http://localhost:9000)
-- [Web-Client](http://localhost:3000)
+- [Web-Client](http://localhost:10000)
 - [Minio-API](http://localhost:9010)
 - [Minio-Client](http://localhost:9011)
 - [Push-dashboard](http://localhost:3001/ui)

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -10,6 +10,9 @@ networks:
 
 services:
   nginx:
+    depends_on:
+      - sama-client
+      - sama-server
     networks:
       sama_network:
         ipv4_address: 172.25.0.8
@@ -19,18 +22,26 @@ services:
       dockerfile: Dockerfile.nginx
     ports:
       - "9000:9000"
+      - "10000:10000"
+    volumes:
+      - sama-client-dist:/usr/share/nginx/html:ro
 
   sama-client:
     build:
       context: ./prefs/client
       dockerfile: Dockerfile.frontend
+      args:
+        VITE_SOCKET_CONNECT: ws://localhost:9000
+        VITE_HTTP_CONNECT: http://localhost:9000
+        VITE_PUBLIC_VAPID_KEY: BNeoP95lfdpIEMTBay5bkjn3VgQHR0fg5feo375mQ7h8kpVh_43HXtISrQnzZwrja83cjCGlBA9FtIOzHeqy4dE
+        VITE_MESSAGES_COUNT_TO_PRELOAD: 30
+        BRANCH: development
     networks:
       sama_network:
         ipv4_address: 172.25.0.9
-    ports:
-      - "3000:3000"
     volumes:
-      - ./prefs/client/.env.frontend:/app/.env
+      - sama-client-dist:/dist
+    command: [ "echo", "Static files are ready" ]
 
   sama-server:
     build:
@@ -166,3 +177,4 @@ services:
 volumes:
   data:
   mongo:
+  sama-client-dist:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -8,6 +8,13 @@ services:
     deploy:
       replicas: 0
 
+  nginx:
+    # Define the service here as an empty object to effectively exclude it
+    # Or simply leave it out if you want to remove it completely
+    # Example:
+    deploy:
+      replicas: 0
+
   sama-server:
     # Define the service here as an empty object to effectively exclude it
     # Or simply leave it out if you want to remove it completely

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ services:
       file: ./prefs/docker-compose/services/frontend.yml
       service: sama-client
 
+  nginx:
+    extends:
+      file: ./prefs/docker-compose/services/frontend.yml
+      service: nginx
+
   sama-server:
     extends:
       file: ./prefs/docker-compose/services/backend.yml
@@ -52,3 +57,4 @@ services:
 volumes:
   data:
   mongo:
+  sama-client-dist:

--- a/prefs/client/.env.frontend
+++ b/prefs/client/.env.frontend
@@ -1,4 +1,5 @@
+# This file can be removed in future (or not)
 VITE_SOCKET_CONNECT=ws://localhost:9000
-VITE_HTTP_CONNECT=http://localhost:9000
+VITE_HTTP_CONNECT=http://localhost:9000 
 VITE_PUBLIC_VAPID_KEY=BNeoP95lfdpIEMTBay5bkjn3VgQHR0fg5feo375mQ7h8kpVh_43HXtISrQnzZwrja83cjCGlBA9FtIOzHeqy4dE
 VITE_MESSAGES_COUNT_TO_PRELOAD=30

--- a/prefs/client/.env.frontend
+++ b/prefs/client/.env.frontend
@@ -1,5 +1,0 @@
-# This file can be removed in future (or not)
-VITE_SOCKET_CONNECT=ws://localhost:9000
-VITE_HTTP_CONNECT=http://localhost:9000 
-VITE_PUBLIC_VAPID_KEY=BNeoP95lfdpIEMTBay5bkjn3VgQHR0fg5feo375mQ7h8kpVh_43HXtISrQnzZwrja83cjCGlBA9FtIOzHeqy4dE
-VITE_MESSAGES_COUNT_TO_PRELOAD=30

--- a/prefs/client/Dockerfile.frontend
+++ b/prefs/client/Dockerfile.frontend
@@ -1,8 +1,12 @@
 FROM alpine/git as clone
 
+ARG BRANCH
+
 WORKDIR /app
+
 RUN git config --global http.version HTTP/1.1
-RUN git clone https://github.com/SAMA-Communications/sama-client.git . --depth 1
+
+RUN git clone --branch ${BRANCH} --single-branch https://github.com/SAMA-Communications/sama-client.git . --depth 1
 
 FROM node:22.14.0 as builder
 
@@ -10,12 +14,23 @@ WORKDIR /app
 
 COPY --from=clone /app .
 
+ARG VITE_SOCKET_CONNECT
+ARG VITE_HTTP_CONNECT
+ARG VITE_PUBLIC_VAPID_KEY
+ARG VITE_MESSAGES_COUNT_TO_PRELOAD
+
 RUN npm install
 
-FROM node:22-slim
+RUN npm install @tailwindcss/oxide lightningcss
 
-WORKDIR /app
+RUN npm run build --workspace=sama-sdk
 
-COPY --from=builder /app /app
+RUN npm run build --workspace=sama
 
-CMD ["npm", "run", "start", "-workspace=sama"]
+FROM alpine as static
+
+WORKDIR /dist
+
+COPY --from=builder /app/apps/client/dist ./
+
+VOLUME ["/dist"]

--- a/prefs/docker-compose/services/db.yml
+++ b/prefs/docker-compose/services/db.yml
@@ -2,8 +2,7 @@ version: "3.8"
 
 services:
   mongo:
-    platform: linux/x86_64
-    image: mongo:6.0
+    image: mongo:6.0.11
     networks:
       sama_network:
         ipv4_address: 172.25.0.4
@@ -16,7 +15,7 @@ services:
     ports:
       - "27017:27017"
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongo localhost:27017/samadb --quiet
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/samadb --quiet
       interval: 30s
       timeout: 20s
       retries: 3

--- a/prefs/docker-compose/services/frontend.yml
+++ b/prefs/docker-compose/services/frontend.yml
@@ -1,15 +1,36 @@
 version: "3.8"
 
+volumes:
+  sama-client-dist:
+
 services:
   sama-client:
     build:
       context: ../../client
       dockerfile: Dockerfile.frontend
-    container_name: "sama-client"
+      args:
+        VITE_SOCKET_CONNECT: ws://localhost:9000
+        VITE_HTTP_CONNECT: http://localhost:9000
+        VITE_PUBLIC_VAPID_KEY: BNeoP95lfdpIEMTBay5bkjn3VgQHR0fg5feo375mQ7h8kpVh_43HXtISrQnzZwrja83cjCGlBA9FtIOzHeqy4dE
+        VITE_MESSAGES_COUNT_TO_PRELOAD: 30
+        BRANCH: development
+    volumes:
+      - sama-client-dist:/dist
+    command: ["echo", "Static files are ready"]
+
+  nginx:
+    depends_on:
+      - sama-client
+      - sama-server
+    container_name: sama-front-nginx
     networks:
       sama_network:
         ipv4_address: 172.25.0.8
+    restart: always
+    build:
+      context: ../../nginx
+      dockerfile: Dockerfile.nginx
     ports:
-      - "3000:3000"
+      - "10000:10000"
     volumes:
-      - ../../client/.env.frontend:/app/.env
+      - sama-client-dist:/usr/share/nginx/html:ro

--- a/prefs/nginx/default.conf
+++ b/prefs/nginx/default.conf
@@ -22,3 +22,21 @@ server {
     resolver 8.8.8.8 ipv6=off;
   }
 }
+
+server {
+  listen 10000;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+
+  error_page 404 /index.html;
+
+  location ~* \.(?:ico|css|js|gif|jpe?g|png|woff2?|eot|ttf|svg)$ {
+    expires max;
+    access_log off;
+  }
+}


### PR DESCRIPTION
This PR proposes a change to the frontend launch process using Vite and static files by building the frontend inside a container and mounting the build output to the Nginx container, which then serves it.

Please pay attention to the port changes, moving environment variables to Docker build arguments, ~~and the fact that this has been implemented only for `docker-compose-full.yml` so far~~.

~~If everyone is fine with this approach, we can consider a better way to implement it in `docker-compose.yml`.~~